### PR TITLE
Switch to phpseclib/phpseclib 3.x

### DIFF
--- a/Amazon/Pay/API/Client.php
+++ b/Amazon/Pay/API/Client.php
@@ -3,7 +3,7 @@
 
     namespace Amazon\Pay\API;
 
-    use phpseclib\Crypt\RSA;
+    use phpseclib3\Crypt\RSA;
 
     require_once 'ClientInterface.php';
     require_once 'HttpCurl.php';
@@ -413,11 +413,6 @@
 
 
         private function setupRSA() {
-            $rsa = new RSA();
-            $rsa->setHash(self::HASH_ALGORITHM);
-            $rsa->setMGFHash(self::HASH_ALGORITHM);
-            $rsa->setSaltLength(20);
-
             $key_spec = $this->config['private_key'];
 
             if ((strpos($key_spec, 'BEGIN RSA PRIVATE KEY') === false) && (strpos($key_spec, 'BEGIN PRIVATE KEY') === false)) {
@@ -425,9 +420,9 @@
                 if ($contents === false) {
                     throw new \Exception('Unable to load file: ' . $key_spec);
                 }
-                $rsa->loadKey($contents);
+                $rsa = RSA::loadPrivateKey($contents)->withSaltLength(20);
             } else {
-                $rsa->loadKey($key_spec);
+                $rsa = RSA::loadPrivateKey($key_spec)->withSaltLength(20);
             }
 
             return $rsa;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
    "require": {
       "ext-curl": "*",
       "php": ">=5.5.0",
-      "phpseclib/phpseclib": "~2.0"
+      "phpseclib/phpseclib": "~3.0"
    },
    "require-dev": {
       "phpunit/phpunit": "^4"

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -4,7 +4,7 @@
     include 'vendor/autoload.php';
     require_once 'Amazon/Pay/API/Client.php';
 
-    use phpseclib\Crypt\RSA;
+    use phpseclib3\Crypt\RSA;
     use PHPUnit\Framework\TestCase;
 
     class ClientTest extends TestCase
@@ -191,13 +191,10 @@
         }
 
         private function verifySignature($plaintext, $signature) {
-            $rsa = new RSA();
-            $rsa->setHash(Client::HASH_ALGORITHM);
-            $rsa->setMGFHash(Client::HASH_ALGORITHM);
-            $rsa->setSaltLength(20);
-            $rsa->loadKey(file_get_contents('tests/unit/unit_test_key_public.txt'));
+            /** @var \phpseclib3\Crypt\Common\PrivateKey $rsa */
+            $rsa = RSA::loadPrivateKey(file_get_contents('tests/unit/unit_test_key_public.txt'))->withSaltLength(20);
 
-            return $rsa->verify($plaintext, base64_decode($signature));
+            return $rsa->getPublicKey()->verify($plaintext, base64_decode($signature));
         }
 
         public function testGenerateButtonSignature() {


### PR DESCRIPTION
Fixes https://github.com/amzn/amazon-pay-api-sdk-php/issues/16

Updates dependency and import, and uses the 3.x api for phpseclib to work with RSA keys. Obviously there are some considerations around versioning because this change would cause issues for platforms that need to still use the 2.x phpseclib, but this is the general change to support 3.x.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
