### PR TITLE
Pass empty string to "hash()" if $data is null

### DIFF
--- a/Amazon/Pay/API/Client.php
+++ b/Amazon/Pay/API/Client.php
@@ -192,7 +192,7 @@
         private function hexAndHash($data)
         {
             $hash = self::HASH_ALGORITHM;
-            return bin2hex(hash($hash, $data, true));
+            return bin2hex(hash($hash, $data ?? '', true));
         }
     
         /* Formats date as ISO 8601 timestamp */


### PR DESCRIPTION
Fixes issue #20 

Basic protection against sending `null` into php's `hash()` function, which is deprecated functionality with php8.1.

Alternate approach could be to update the various `apiCall` to pass in empty string instead of null for the payload, but I'm not entirely sure if that could have other side effects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
