### PR TITLE
feature(Client): allow proxy for HttpCurl class

### DIFF
--- a/Amazon/Pay/API/Client.php
+++ b/Amazon/Pay/API/Client.php
@@ -479,7 +479,7 @@
                 }
             }
 
-            $httpCurlRequest = new HttpCurl();
+            $httpCurlRequest = new HttpCurl(isset($this->config['request_options']) ? $this->config['request_options'] : []);
             $response = $httpCurlRequest->invokeCurl($method, $url, $payload, $postSignedHeaders);
             return $response;
         }

--- a/Amazon/Pay/API/HttpCurl.php
+++ b/Amazon/Pay/API/HttpCurl.php
@@ -11,6 +11,14 @@ class HttpCurl
 
     private $curlResponseInfo = null;
     private $requestId = null;
+    private $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct ($config = []) {
+        $this->config = $config;
+    }
 
     private function header_callback($ch, $header_line)
     {
@@ -39,6 +47,11 @@ class HttpCurl
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_HEADERFUNCTION, array($this, 'header_callback'));
+
+        if ($this->useProxy()) {
+            curl_setopt($ch, CURLOPT_PROXY, $this->config['proxy']['host'] . ':' . $this->config['proxy']['port']);
+            curl_setopt($ch, CURLOPT_PROXYUSERPWD, $this->config['proxy']['username'] . ':' . $this->config['proxy']['password']);
+        }
 
         return $ch;
     }
@@ -153,6 +166,9 @@ class HttpCurl
         }
     }
 
+    private function useProxy() {
+        return !empty($this->config['proxy']['username']) && !empty($this->config['proxy']['password']) && !empty($this->config['proxy']['host']) && !empty($this->config['proxy']['port']);
+    }
 }
 
 ?>

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -13,7 +13,22 @@
             'public_key_id' => 'ABC123DEF456XYZ789IJK000',
             'private_key'   => 'tests/unit/unit_test_key_private.txt',
             'sandbox'       => true,
-            'region'        => 'us'
+            'region'        => 'us',
+            'request_options' => [
+                'proxy' => [
+                    'username' => 'foo',
+                    'password' => 'bar'
+                ]
+            ]
+        );
+
+        private $requestOptionsConfig = array(
+            'request_options' => [
+                'proxy' => [
+                    'username' => 'foo',
+                    'password' => 'bar'
+                ]
+            ]
         );
 
         private $requestParameters = array(
@@ -51,6 +66,14 @@
             $this->assertEquals($this->configParams['private_key'], $client->__get('private_key'));
             $this->assertEquals($this->configParams['sandbox'], $client->__get('sandbox'));
             $this->assertEquals($this->configParams['region'], $client->__get('region'));
+        }
+
+        public function testRequestOptionsConfig() {
+            $client = new Client($this->requestOptionsConfig);
+
+            $this->assertArrayHasKey('proxy', $client->__get('request_options'));
+            $this->assertEquals('foo', $client->__get('request_options')['proxy']['username']);
+            $this->assertEquals('bar', $client->__get('request_options')['proxy']['password']);
         }
 
         public function testGetCanonicalURI()
@@ -311,7 +334,7 @@
             );
             $reflectionMethod = self::getMethod('createServiceUrl');
             $client = new Client($payConfig);
-            
+
             // Building URL
             $actualURL = $reflectionMethod->invoke($client);
 

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -68,7 +68,7 @@
             $this->assertEquals($this->configParams['region'], $client->__get('region'));
         }
 
-        public function testRequestOptionsConfig() {
+        public function testGetRequestOptionsConfig() {
             $client = new Client($this->requestOptionsConfig);
 
             $this->assertArrayHasKey('proxy', $client->__get('request_options'));


### PR DESCRIPTION
*Issue #, if available:*
Currently the SDK cannot handle proxy for cURL.

*Description of changes:*
Similar solution to  your V1: 
The dev can provide proxy-credentials via `$config`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
