### PR TITLE
Fix readme: required phpseclib

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you need to make an Amazon Pay API call that uses the mws.amazonservices.com|
 
 * PHP 5.5 or higher, but highly recommended to use only the latest PHP version, and update often, to ensure current security fixes are applied
 * Curl 7.18 or higher
-* phpseclib 2.0
+* phpseclib 3.0
 
 ## SDK Installation
 


### PR DESCRIPTION
*Issue #, if available:*

Nothing

*Description of changes:*

The version of phpseclib written in the requirements is different from the one in [`composer.json`](https://github.com/amzn/amazon-pay-api-sdk-php/blob/4583b7320e96e18fe32bef1830d7a968c0cebf49/composer.json#L31), which has been corrected.

