### PR TITLE
fix PHP version issues

### DIFF
--- a/Amazon/Pay/API/Client.php
+++ b/Amazon/Pay/API/Client.php
@@ -360,10 +360,13 @@
                 'x-amz-pay-region' => $this->config['region'],
                 'x-amz-pay-sdk-type' => self::SDK_LANGUAGE,
                 'x-amz-pay-sdk-version' => self::SDK_VERSION,
-                'x-amz-pay-language-version' => PHP_VERSION,
                 'authorization' => $this->getAlgorithm() . " PublicKeyId=" . $public_key_id . ", " . $signedHeaders,
                 'user-agent' => $this->constructUserAgentHeader()
             );
+
+            if(preg_match('/^\d+.\d+.\d+/', phpversion(), $match)){
+                $headerArray['x-amz-pay-language-version'] = $match[0];
+            }
 
             if(isset($this->config['integrator_id'])){
                 $headerArray['x-amz-pay-integrator-id'] = $this->config['integrator_id'];


### PR DESCRIPTION
Submitting the PHP version as it is in the `x-amz-pay-language-version` header causes InvalidHeaderValue errors (`The formats for [x-amz-pay-language-version] are not supported.`) for quite a lot of PHP versions because the API does not support the common alphanumeric suffixes.

Examples that I have encountered:
`5.6.40-nmm6`, `7.2.34-39+ubuntu22.04.1+[deb.sury.org](http://deb.sury.org/)+1`

This makes sandbox testing impossible on those servers. 
Therefore, I'd suggest filtering the version to only submit accepted values.