### PR TITLE
Remove deprecated curl_close() call for PHP 8.5

### DIFF
--- a/Amazon/Pay/API/HttpCurl.php
+++ b/Amazon/Pay/API/HttpCurl.php
@@ -82,12 +82,12 @@ class HttpCurl
         $response = curl_exec($ch);
         if ($response === false) {
             $error_msg = "Unable to send request, underlying exception of " . curl_error($ch);
-            curl_close($ch);
+            unset($ch);
             throw new \Exception($error_msg);
         } else {
             $this->curlResponseInfo = curl_getinfo($ch);
         }
-        curl_close($ch);
+        unset($ch);
         return $response;
     }
 


### PR DESCRIPTION
Fixes a fatal error on PHP 8.5 where Amazon Pay Web API requests die with:

  > Deprecated Functionality: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in 
  vendor/amzn/amazon-pay-api-sdk-php/Amazon/Pay/API/HttpCurl.php on line 90
